### PR TITLE
Fix duplicate ids in LIFF demo

### DIFF
--- a/line-liff-poc.html
+++ b/line-liff-poc.html
@@ -13,8 +13,7 @@
   <p id="displayName"></p>
   <p id="statusMessage"></p>
   <p id="getDecodedIDToken"></p>
-  <p id="userId"></p>
-  <p id="userId"></p>
+  <p id="sub"></p>
   <script src="https://static.line-scdn.net/liff/edge/versions/2.9.0/sdk.js"></script>
   <script>
     function runApp() {


### PR DESCRIPTION
## Summary
- clean up the LIFF demo page by removing duplicated `userId` elements
- add missing element for `sub`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c1a41df808322825ef1b3ec4d40f6