### PR TITLE
Add copy function to JSON beautifier

### DIFF
--- a/json-beautify.html
+++ b/json-beautify.html
@@ -18,6 +18,11 @@
             margin-top: 10px;
             padding: 8px 16px;
         }
+        .copy-message {
+            margin-left: 10px;
+            color: green;
+            display: none;
+        }
         #output {
             background-color: #f4f4f4;
             padding: 10px;
@@ -36,17 +41,22 @@
     <button id="beautifyBtn">Beautify JSON</button>
     <button id="expandAll" style="display:none;">Expand All</button>
     <button id="collapseAll" style="display:none;">Collapse All</button>
+    <button id="copyBtn" style="display:none;">Copy JSON</button>
+    <span id="copyMessage" class="copy-message">Copied!</span>
     <div id="output"></div>
     <script>
+        let formattedJson = '';
         $('#beautifyBtn').on('click', function () {
             const input = $('#jsonInput').val();
             try {
                 const obj = JSON.parse(input);
                 $('#output').JSONView(obj);
-                $('#expandAll, #collapseAll').show();
+                $('#expandAll, #collapseAll, #copyBtn').show();
+                formattedJson = JSON.stringify(obj, null, 4);
             } catch (e) {
                 $('#output').text('Invalid JSON: ' + e.message);
-                $('#expandAll, #collapseAll').hide();
+                $('#expandAll, #collapseAll, #copyBtn').hide();
+                formattedJson = '';
             }
         });
 
@@ -56,6 +66,16 @@
 
         $('#collapseAll').on('click', function () {
             $('#output').JSONView('collapse');
+        });
+
+        $('#copyBtn').on('click', function () {
+            if (!formattedJson) return;
+            navigator.clipboard.writeText(formattedJson).then(function () {
+                $('#copyMessage').show();
+                setTimeout(function () {
+                    $('#copyMessage').hide();
+                }, 1500);
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add copy-message style
- add Copy JSON button and feedback
- store formatted JSON for copying
- implement clipboard logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c2398304c8322ae7c8492f12f72a5