### PR TITLE
Add Data Formatter v3 link and beautify UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Access the currency conversion tool:
 ## JSON/XML Formatter – Data Formatter
 Format your JSON or XML data easily:
 - [Data Formatter](https://megabosssa.github.io/public-html-service/data%20formatter%20v2.html)
+- [Data Formatter v3](https://megabosssa.github.io/public-html-service/v3/objectParser.html)
 
 ## JSON Beautifier
 Pretty-print and explore JSON data with collapsible objects:

--- a/v3/objectParser.html
+++ b/v3/objectParser.html
@@ -7,18 +7,19 @@
         /* Global Styles */
         body {
             font-family: Arial, sans-serif;
-            background-color: #f9f9f9;
+            background: linear-gradient(135deg, #e0e7ff, #fdfbff);
             margin: 0;
             padding: 0;
             color: #333;
+            min-height: 100vh;
         }
         .container {
             max-width: 800px;
             margin: 40px auto;
             background: #fff;
-            padding: 20px 30px;
-            border-radius: 8px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
         }
         h2 {
             text-align: center;
@@ -33,6 +34,7 @@
         .controls label {
             margin-right: 15px;
             font-size: 1rem;
+            font-weight: 600;
         }
         textarea {
             width: 100%;
@@ -43,6 +45,7 @@
             border-radius: 4px;
             resize: vertical;
             margin-bottom: 15px;
+            box-sizing: border-box;
         }
         button {
             padding: 10px 25px;
@@ -52,16 +55,20 @@
             border: none;
             border-radius: 4px;
             cursor: pointer;
-            transition: background-color 0.3s ease;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+            transition: background-color 0.3s ease, box-shadow 0.3s ease;
         }
         button:hover {
             background-color: #357ae8;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.2);
         }
         /* Table Styles */
         table {
             border-collapse: collapse;
             width: 100%;
             margin-top: 20px;
+            border-radius: 6px;
+            overflow: hidden;
         }
         table, th, td {
             border: 1px solid #ddd;
@@ -72,6 +79,9 @@
         }
         th {
             background-color: #f2f2f2;
+        }
+        tr:nth-child(even) {
+            background-color: #f9f9f9;
         }
         #output {
             margin-top: 20px;


### PR DESCRIPTION
## Summary
- add Data Formatter v3 entry in README index
- enhance Data Formatter v3 styles with gradients, shadows and zebra tables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c253a83c88322ba89f87766610744