### PR TITLE
Use public timeout service

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ Convert JSON files to CSV format:
 View logs (from the OCP console) in an HTML table format:
 - [Log Formatter](https://megabosssa.github.io/public-html-service/log-formatter-v2.html)
 
-## Endpoint Hold Response
-Test timeout scenarios with this endpoint:
-- [Endpoint Hold Response](https://api-factory-dev.apps.ocp-test.krungsri.net/mock/v1/sleep?time=30000)
+## Timeout Simulator
+Test delayed responses using the public `httpstat.us` service. For example:
+`https://httpstat.us/200?sleep=5000` waits five seconds before replying.
+Use the page below to experiment with different delays:
+- [Timeout Simulator](https://megabosssa.github.io/public-html-service/timeout-simulator.html)
 
 ## Generic Currency Converter
 Another instance of the currency conversion service:

--- a/timeout-simulator.html
+++ b/timeout-simulator.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Timeout Simulator</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+        label, button {
+            display: block;
+            margin-top: 10px;
+        }
+        input {
+            padding: 5px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Timeout Simulator</h1>
+    <label>
+        Delay (ms):
+        <input type="number" id="delayInput" value="3000" min="0" step="1000">
+    </label>
+    <button id="startBtn">Call Timeout API</button>
+    <p id="status"></p>
+
+    <script>
+        document.getElementById('startBtn').addEventListener('click', async function() {
+            const delay = parseInt(document.getElementById('delayInput').value, 10) || 0;
+            const status = document.getElementById('status');
+            const btn = this;
+
+            btn.disabled = true;
+            status.textContent = `Calling API with delay ${delay} ms...`;
+
+            try {
+                const start = Date.now();
+                const response = await fetch(`https://httpstat.us/200?sleep=${delay}`);
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}`);
+                }
+                const elapsed = Date.now() - start;
+                status.textContent = `API responded with status ${response.status} after ${elapsed} ms.`;
+            } catch (err) {
+                status.textContent = `Request failed: ${err}`;
+            } finally {
+                btn.disabled = false;
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove Node-based timeout API
- rewrite timeout simulator page to call `httpstat.us` for delays
- drop unused npm script
- document using the public service in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c2647213c8322a2c691512ecb7c40