### PR TITLE
Fix dark mode toggle in JSON beautify page

### DIFF
--- a/json-beautify.html
+++ b/json-beautify.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Advanced JSON Tools</title>
     <!-- Tailwind CSS for styling -->
+    <script>
+        tailwind.config = { darkMode: 'class' }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- jQuery for JSONView plugin -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>


### PR DESCRIPTION
## Summary
- configure Tailwind to use class based dark mode so the toggle works

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684cc0ce59c08322b8dc125f7345f7d0