### PR TITLE
Improve nav styling across tools

### DIFF
--- a/aes-256-gcm.html
+++ b/aes-256-gcm.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="global.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>JWE Encryption/Decryption</title>
     <script src="https://cdn.jsdelivr.net/npm/jose@3.14.0/dist/browser/jose.min.js"></script>
@@ -21,7 +22,7 @@
     </style>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
     <h1>JWE Encryption/Decryption</h1>

--- a/data formatter v2.html
+++ b/data formatter v2.html
@@ -2,13 +2,14 @@
 <html>
 <head>
     <title>Data Formatter</title>
-	<link rel="icon" type="image/png" href="resources/img/anya_icon.jpg">
+    <link rel="stylesheet" href="global.css">
+        <link rel="icon" type="image/png" href="resources/img/anya_icon.jpg">
     <style>
 
     </style>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
     <h2>Data Formatter</h2>

--- a/generateReportCSV.html
+++ b/generateReportCSV.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="global.css">
     <title>JSON to CSV Converter with Download</title>
     <style>
         textarea { width: 300px; height: 200px; }
@@ -9,7 +10,7 @@
     </style>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
 <h1>JSON to CSV Converter with Download</h1>

--- a/global.css
+++ b/global.css
@@ -1,0 +1,25 @@
+.simple-nav {
+    margin-bottom: 20px;
+    background: #f0f0f0;
+    padding: 10px;
+    border-radius: 4px;
+}
+
+.simple-nav a {
+    color: #333;
+    text-decoration: none;
+    margin-right: 10px;
+    font-weight: 600;
+}
+
+.simple-nav a:hover {
+    text-decoration: underline;
+}
+
+.dark .simple-nav {
+    background: #2d3748;
+}
+
+.dark .simple-nav a {
+    color: #f8f9fa;
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Utility Tools</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link rel="stylesheet" href="global.css">
     <style>
         body {
             background-color: #f8f9fa;

--- a/json-beautify.html
+++ b/json-beautify.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="global.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Advanced JSON Tools</title>
     <!-- Tailwind CSS for styling -->
@@ -60,7 +61,7 @@
     </style>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-300">
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
 

--- a/line-liff-poc.html
+++ b/line-liff-poc.html
@@ -1,6 +1,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+    <link rel="stylesheet" href="global.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>My LIFF v2</title>
   <style>
@@ -8,7 +9,7 @@
   </style>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
   <img id="pictureUrl" width="25%">

--- a/line-lift-poc-2.html
+++ b/line-lift-poc-2.html
@@ -2,11 +2,12 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="global.css">
     <title>LIFF App</title>
     <script src="https://static.line-scdn.net/liff/edge/2.15.1/sdk.js"></script>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
     <h1>LIFF App</h1>

--- a/log-formatter-v2.html
+++ b/log-formatter-v2.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="global.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>JSON Log to HTML Table</title>
     <style>
@@ -56,7 +57,7 @@
     </style>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
 

--- a/log-formatter.html
+++ b/log-formatter.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="global.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>JSON Log to HTML Table</title>
     <style>
@@ -49,7 +50,7 @@
     </style>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
 

--- a/rate-conversion.html
+++ b/rate-conversion.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="global.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Generic Currency Converter</title>
     <style>
@@ -82,7 +83,7 @@
     </style>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
 

--- a/stock-dr-convertion.html
+++ b/stock-dr-convertion.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="global.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DR Price Calculator</title>
     <style>
@@ -44,7 +45,7 @@
     </style>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
 

--- a/timeout-simulator.html
+++ b/timeout-simulator.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link rel="stylesheet" href="global.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Timeout Simulator</title>
     <style>
@@ -19,7 +20,7 @@
     </style>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
     <h1>Timeout Simulator</h1>

--- a/v3/objectParser.html
+++ b/v3/objectParser.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Data Formatter With Length</title>
+    <link rel="stylesheet" href="../global.css">
     <link rel="icon" type="image/png" href="resources/img/anya_icon.jpg">
     <style>
         /* Global Styles */
@@ -89,7 +90,7 @@
     </style>
 </head>
 <body>
-<nav style="margin-bottom:20px;background:#f0f0f0;padding:10px;border-radius:4px;">
+<nav class="simple-nav">
  <a href="../index.html">Home</a> | <a href="javascript:history.back()">Back</a>
 </nav>
     <div class="container">


### PR DESCRIPTION
## Summary
- add global nav styles for light/dark themes
- include the new stylesheet on all tool pages
- switch every page to use `<nav class="simple-nav">`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d2920a5188322a33de335fd788080