### PR TITLE
Add Dynatrace log viewer to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Convert JSON files to CSV format:
 ## Log Viewer – JSON Log to HTML Table
 View logs (from the OCP console) in an HTML table format:
 - [Log Formatter](https://megabosssa.github.io/public-html-service/log-formatter-v2.html)
+- [Dynatrace Log Viewer](https://megabosssa.github.io/public-html-service/Dynatrace%20JSON%20Log%20Viewer%20with%20Summary%20View.html)
 
 ## Timeout Simulator
 Test delayed responses using the public `httpstat.us` service. For example:

--- a/index.html
+++ b/index.html
@@ -177,6 +177,15 @@
                 </div>
             </a>
         </div>
+        <div class="col tool-item">
+            <a href="Dynatrace JSON Log Viewer with Summary View.html" class="card h-100 text-decoration-none tool-card">
+                <div class="card-body text-center p-4">
+                    <i class="bi bi-clipboard-data display-4"></i>
+                    <h5 class="card-title mt-3">Dynatrace Log Viewer</h5>
+                    <p class="card-text small text-muted">Analyze Dynatrace logs with summary view.</p>
+                </div>
+            </a>
+        </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- link Dynatrace JSON log viewer from homepage
- document Dynatrace viewer in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686682cd22988322a5e4701bbb136e11